### PR TITLE
Update card

### DIFF
--- a/layouts/partials/home.html
+++ b/layouts/partials/home.html
@@ -4,7 +4,7 @@
     {{ partial "menu-tags.html" . }}
     
     <div class="grid-posts">
-    {{ $paginator := .Paginate (where .Site.Pages "Params.type" "post") }}
+    {{ $paginator := .Paginate (where .Site.Pages "Params.type" "post") 9 }}
     {{ range $paginator.Pages }}
         <article class="post">
             <div class="post__inner">

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -297,7 +297,10 @@ hr {
     position: relative;
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: flex-start;
+    gap: 1.5rem;
+
+    padding: 1.25rem 0;
 }
 
 .post__footer {
@@ -312,6 +315,7 @@ hr {
 
 .post__header h3 {
     margin: 0;
+    margin-top: -.375em;
     color: var(--primary-text-color);
     font-weight: 500;
     font-size: 16px;

--- a/static/styles/style.css
+++ b/static/styles/style.css
@@ -329,6 +329,13 @@ hr {
     border-radius: 4px;
 }
 
+.post__header a svg {
+    width: 1rem;
+    height: 1rem;
+
+    opacity: .4;
+}
+
 .post__meta {
     display: flex;
     flex-direction: row;


### PR DESCRIPTION
This PR updates:
- The number of posts per page to 9 (default was 10)
- Makes the source logos smaller
- Turns down opacity to source logos (so they don't stand out much)
- Optically align the text with the logo, so they're consistent even if the text has multiple lines.

### Before

<img width="1368" alt="Screenshot 2024-04-20 at 11 28 07 PM" src="https://github.com/frrrnd/viewport/assets/101464991/cfec571f-13e9-4073-8ae6-a5781ca5d88f">

### After

<img width="1377" alt="Screenshot 2024-04-20 at 11 28 41 PM" src="https://github.com/frrrnd/viewport/assets/101464991/fd728f82-1473-418e-86ad-1c654c874dbc">
